### PR TITLE
Handle all potential errors to avoid panics and remove unused stuff.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,10 @@
 
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use ark_vrf::reexports::{
-    ark_serialize::{self, CanonicalDeserialize, CanonicalSerialize},
-};
+use ark_vrf::reexports::ark_serialize::{self, CanonicalDeserialize, CanonicalSerialize};
 use ark_vrf::suites::bandersnatch;
 use bandersnatch::{
-    BandersnatchSha512Ell2, IetfProof, Input, Output, Public, RingProof,
-    RingProofParams, Secret,
+    BandersnatchSha512Ell2, IetfProof, Input, Output, Public, RingProof, RingProofParams, Secret,
 };
 
 #[derive(Clone, Copy)]
@@ -51,7 +48,8 @@ fn ring_proof_params(ring_size: RingSize) -> &'static RingProofParams {
     let init = |size: usize| {
         use bandersnatch::PcsParams;
         let buf = include_bytes!("../data/zcash-srs-2-11-uncompressed.bin");
-        let pcs_params = PcsParams::deserialize_uncompressed_unchecked(&mut &buf[..]).expect("binary data invalid");
+        let pcs_params = PcsParams::deserialize_uncompressed_unchecked(&mut &buf[..])
+            .expect("binary data invalid");
         RingProofParams::from_pcs_params(size, pcs_params).expect("invalid ring proof params")
     };
 
@@ -108,7 +106,8 @@ impl Verifier {
     ) -> Result<[u8; 32], Error> {
         use ark_vrf::ring::Verifier as _;
 
-        let signature = RingVrfSignature::deserialize_compressed(signature).map_err(|_| Error::InvalidSignature)?;
+        let signature = RingVrfSignature::deserialize_compressed(signature)
+            .map_err(|_| Error::InvalidSignature)?;
 
         let input = vrf_input_point(vrf_input_data)?;
         let output = signature.output;
@@ -147,7 +146,8 @@ impl Verifier {
     ) -> Result<[u8; 32], Error> {
         use ark_vrf::ietf::Verifier as _;
 
-        let signature = IetfVrfSignature::deserialize_compressed(signature).map_err(|_| Error::InvalidSignature)?;
+        let signature = IetfVrfSignature::deserialize_compressed(signature)
+            .map_err(|_| Error::InvalidSignature)?;
 
         let input = vrf_input_point(vrf_input_data)?;
         let output = signature.output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,11 @@
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use ark_vrf::reexports::{
-    ark_ec::AffineRepr,
     ark_serialize::{self, CanonicalDeserialize, CanonicalSerialize},
 };
-use ark_vrf::{pedersen::PedersenSuite, ring::RingSuite, suites::bandersnatch};
+use ark_vrf::suites::bandersnatch;
 use bandersnatch::{
-    AffinePoint, BandersnatchSha512Ell2, IetfProof, Input, Output, Public, RingProof,
+    BandersnatchSha512Ell2, IetfProof, Input, Output, Public, RingProof,
     RingProofParams, Secret,
 };
 
@@ -52,8 +51,8 @@ fn ring_proof_params(ring_size: RingSize) -> &'static RingProofParams {
     let init = |size: usize| {
         use bandersnatch::PcsParams;
         let buf = include_bytes!("../data/zcash-srs-2-11-uncompressed.bin");
-        let pcs_params = PcsParams::deserialize_uncompressed_unchecked(&mut &buf[..]).unwrap();
-        RingProofParams::from_pcs_params(size, pcs_params).unwrap()
+        let pcs_params = PcsParams::deserialize_uncompressed_unchecked(&mut &buf[..]).expect("binary data invalid");
+        RingProofParams::from_pcs_params(size, pcs_params).expect("invalid ring proof params")
     };
 
     match ring_size {
@@ -63,78 +62,15 @@ fn ring_proof_params(ring_size: RingSize) -> &'static RingProofParams {
 }
 
 // Construct VRF Input Point from arbitrary data (section 1.2)
-fn vrf_input_point(vrf_input_data: &[u8]) -> Input {
-    Input::new(vrf_input_data).unwrap()
+fn vrf_input_point(vrf_input_data: &[u8]) -> Result<Input, Error> {
+    Input::new(vrf_input_data).ok_or(Error::InvalidPointData)
 }
 
-// Prover actor.
-struct Prover {
-    pub prover_idx: usize,
-    pub secret: Secret,
-    pub ring: Vec<Public>,
-    pub size: RingSize,
-}
-
-impl Prover {
-    pub fn new(size: RingSize, ring: Vec<Public>, prover_idx: usize) -> Self {
-        Self {
-            size,
-            prover_idx,
-            secret: Secret::from_seed(&prover_idx.to_le_bytes()),
-            ring,
-        }
-    }
-
-    /// VRF output hash.
-    pub fn vrf_output(&self, vrf_input_data: &[u8]) -> Vec<u8> {
-        let input = vrf_input_point(vrf_input_data);
-        let output = self.secret.output(input);
-        output.hash()[..32].into()
-    }
-
-    /// Anonymous VRF signature.
-    ///
-    /// Used for tickets submission.
-    pub fn ring_vrf_sign(&self, vrf_input_data: &[u8], aux_data: &[u8]) -> Vec<u8> {
-        use ark_vrf::ring::Prover as _;
-
-        let input = vrf_input_point(vrf_input_data);
-        let output = self.secret.output(input);
-
-        // Backend currently requires the wrapped type (plain affine points)
-        let pts: Vec<_> = self.ring.iter().map(|pk| pk.0).collect();
-
-        // Proof construction
-        let ring_params = ring_proof_params(self.size);
-        let prover_key = ring_params.prover_key(&pts);
-        let prover = ring_params.prover(prover_key, self.prover_idx);
-        let proof = self.secret.prove(input, output, aux_data, &prover);
-
-        // Output and Ring Proof bundled together (as per section 2.2)
-        let signature = RingVrfSignature { output, proof };
-        let mut buf = Vec::new();
-        signature.serialize_compressed(&mut buf).unwrap();
-        buf
-    }
-
-    /// Non-Anonymous VRF signature.
-    ///
-    /// Used for ticket claiming during block production.
-    /// Not used with Safrole test vectors.
-    pub fn ietf_vrf_sign(&self, vrf_input_data: &[u8], aux_data: &[u8]) -> Vec<u8> {
-        use ark_vrf::ietf::Prover as _;
-
-        let input = vrf_input_point(vrf_input_data);
-        let output = self.secret.output(input);
-
-        let proof = self.secret.prove(input, output, aux_data);
-
-        // Output and IETF Proof bundled together (as per section 2.2)
-        let signature = IetfVrfSignature { output, proof };
-        let mut buf = Vec::new();
-        signature.serialize_compressed(&mut buf).unwrap();
-        buf
-    }
+#[derive(Debug)]
+pub enum Error {
+    InvalidPointData,
+    InvalidSignature,
+    VerificationFailure,
 }
 
 type RingCommitment = ark_vrf::ring::RingCommitment<BandersnatchSha512Ell2>;
@@ -169,12 +105,12 @@ impl Verifier {
         vrf_input_data: &[u8],
         aux_data: &[u8],
         signature: &[u8],
-    ) -> Result<[u8; 32], ()> {
+    ) -> Result<[u8; 32], Error> {
         use ark_vrf::ring::Verifier as _;
 
-        let signature = RingVrfSignature::deserialize_compressed(signature).unwrap();
+        let signature = RingVrfSignature::deserialize_compressed(signature).map_err(|_| Error::InvalidSignature)?;
 
-        let input = vrf_input_point(vrf_input_data);
+        let input = vrf_input_point(vrf_input_data)?;
         let output = signature.output;
 
         let ring_params = ring_proof_params(self.ring_size);
@@ -188,14 +124,12 @@ impl Verifier {
         let verifier = ring_params.verifier(verifier_key);
         if Public::verify(input, output, aux_data, &signature.proof, &verifier).is_err() {
             println!("Ring signature verification failure");
-            return Err(());
+            return Err(Error::VerificationFailure);
         }
         println!("Ring signature verified");
 
         // This truncated hash is the actual value used as ticket-id/score in JAM
-        let vrf_output_hash: [u8; 32] = output.hash()[..32].try_into().unwrap();
-        println!(" vrf-output-hash: {}", hex::encode(vrf_output_hash));
-        Ok(vrf_output_hash)
+        Ok(vrf_output_hash(output))
     }
 
     /// Non-Anonymous VRF signature verification.
@@ -210,12 +144,12 @@ impl Verifier {
         aux_data: &[u8],
         signature: &[u8],
         signer_key_index: usize,
-    ) -> Result<[u8; 32], ()> {
+    ) -> Result<[u8; 32], Error> {
         use ark_vrf::ietf::Verifier as _;
 
-        let signature = IetfVrfSignature::deserialize_compressed(signature).unwrap();
+        let signature = IetfVrfSignature::deserialize_compressed(signature).map_err(|_| Error::InvalidSignature)?;
 
-        let input = vrf_input_point(vrf_input_data);
+        let input = vrf_input_point(vrf_input_data)?;
         let output = signature.output;
 
         let public = &self.ring[signer_key_index];
@@ -224,111 +158,22 @@ impl Verifier {
             .is_err()
         {
             println!("Ring signature verification failure");
-            return Err(());
+            return Err(Error::VerificationFailure);
         }
         println!("Ietf signature verified");
 
         // This is the actual value used as ticket-id/score
         // NOTE: as far as vrf_input_data is the same, this matches the one produced
         // using the ring-vrf (regardless of aux_data).
-        let vrf_output_hash: [u8; 32] = output.hash()[..32].try_into().unwrap();
-        println!(" vrf-output-hash: {}", hex::encode(vrf_output_hash));
-        Ok(vrf_output_hash)
+        Ok(vrf_output_hash(output))
     }
 }
 
-macro_rules! measure_time {
-    ($func_name:expr, $func_call:expr) => {{
-        let start = std::time::Instant::now();
-        let result = $func_call;
-        let duration = start.elapsed();
-        println!("* Time taken by {}: {:?}", $func_name, duration);
-        result
-    }};
-}
-
-fn print_point(name: &str, p: AffinePoint) {
-    println!("------------------------------");
-    println!("[{name}]");
-    println!("X: {}", p.x);
-    println!("Y: {}", p.y);
-    let mut buf = Vec::new();
-    p.serialize_compressed(&mut buf).unwrap();
-    println!("Compressed: 0x{}", hex::encode(buf));
-}
-
-fn print_points() {
-    println!("==============================");
-    print_point("Group Base", AffinePoint::generator());
-    print_point("Blinding Base", BandersnatchSha512Ell2::BLINDING_BASE);
-    print_point("Ring Padding", BandersnatchSha512Ell2::PADDING);
-    print_point("Accumulator Base", BandersnatchSha512Ell2::ACCUMULATOR_BASE);
-    println!("==============================");
-}
-
-#[wasm_bindgen]
-pub fn verify_safrole() -> bool {
-    let ring_size = RingSize::Full;
-    let ring_len: i32 = ring_size.size() as i32;
-
-    print_points();
-
-    let mut ring: Vec<_> = (0..ring_len)
-        .map(|i| Secret::from_seed(&i.to_le_bytes()).public())
-        .collect();
-    let prover_key_index = 3;
-
-    // NOTE: any key can be replaced with the padding point
-    let padding_point = Public::from(RingProofParams::padding_point());
-    ring[2] = padding_point;
-    ring[7] = padding_point;
-
-    let prover = Prover::new(ring_size, ring.clone(), prover_key_index);
-    let verifier = Verifier::new(ring_size, ring);
-
-    let vrf_input_data = b"foo";
-
-    //--- Anonymous VRF
-
-    let aux_data = b"bar";
-
-    // Prover signs some data.
-    let ring_signature = measure_time! {
-        "ring-vrf-sign",
-        prover.ring_vrf_sign(vrf_input_data, aux_data)
-    };
-
-    // Verifier checks it without knowing who is the signer.
-    let ring_vrf_output_hash = measure_time! {
-        "ring-vrf-verify",
-        verifier.ring_vrf_verify(vrf_input_data, aux_data, &ring_signature).unwrap()
-    };
-
-    //--- Non anonymous VRF
-
-    let other_aux_data = b"hello";
-
-    // Prover signs the same vrf-input data (we want the output to match)
-    // But different aux data.
-    let ietf_signature = measure_time! {
-        "ietf-vrf-sign",
-        prover.ietf_vrf_sign(vrf_input_data, other_aux_data)
-    };
-
-    // Verifier checks the signature knowing the signer identity.
-    let ietf_vrf_output_hash = measure_time! {
-        "ietf-vrf-verify",
-        verifier.ietf_vrf_verify(vrf_input_data, other_aux_data, &ietf_signature, prover_key_index).unwrap()
-    };
-
-    // Must match
-    assert_eq!(ring_vrf_output_hash, ietf_vrf_output_hash);
-
-    // We don't need to produce a signature to get the vrf output
-    let vrf_output_hash = prover.vrf_output(vrf_input_data);
-    assert_eq!(vrf_output_hash, ietf_vrf_output_hash);
-
-    true
+fn vrf_output_hash(output: Output) -> [u8; 32] {
+    let mut vrf_output_hash = [0u8; 32];
+    vrf_output_hash.copy_from_slice(&output.hash()[..32]);
+    println!(" vrf-output-hash: {}", hex::encode(vrf_output_hash));
+    vrf_output_hash
 }
 
 fn create_verifier(keys: &[u8]) -> Verifier {


### PR DESCRIPTION
I've removed the stuff that's unused currently (smaller `wasm` blob), but I think it will need to be added again for: https://github.com/FluffyLabs/typeberry/issues/387

Motivation: Current block generator in typeberry (doing some random seals) is able to crash the library, so I'd rather have an error and see the block rejected instead.