### PR TITLE
fix(ci): fix publish workflow script quoting issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Update versions
         run: |
-          node -e "
+          cat <<'EOF' > update_versions.js
           const fs = require('fs');
           const shortSha = '${{ steps.vars.outputs.short_sha }}';
           
@@ -149,7 +149,9 @@ jobs:
               fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
             }
           }
-          "
+          EOF
+          
+          node update_versions.js
 
       - name: Publish platform packages
         env:


### PR DESCRIPTION
## Summary
The `publish` job failed because the inline Node.js script was being interpreted by the shell, causing syntax errors with template literals and variable substitution.

## Changes
- Moved the inline Node.js script to a file using `cat <<'EOF'` to prevent shell expansion of JS code.
- Executed the script file using `node`.

## Testing
This change ensures that JavaScript template literals (backticks) and `${}` inside the script are passed correctly to Node.js without shell interference.