### PR TITLE
fix(ci): use cjs extension for update_versions script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Update versions
         run: |
-          cat <<'EOF' > update_versions.js
+          cat <<'EOF' > update_versions.cjs
           const fs = require('fs');
           const shortSha = '${{ steps.vars.outputs.short_sha }}';
           
@@ -151,7 +151,7 @@ jobs:
           }
           EOF
           
-          node update_versions.js
+          node update_versions.cjs
 
       - name: Publish platform packages
         env:


### PR DESCRIPTION
## Summary
The `publish` job failed because `update_versions.js` uses `require`, but the project is configured as an ES module, causing Node.js to throw a `ReferenceError`.

## Changes
- Renamed the inline script file from `update_versions.js` to `update_versions.cjs` in the `cat` command.
- Updated the `node` execution command to run `update_versions.cjs`.

## Testing
This forces Node.js to treat the script as CommonJS, allowing `require` to work correctly regardless of the `package.json` "type" field.