### PR TITLE
Update nodejs from 22 to 24 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: 'npm'
       - name: Install deps


### PR DESCRIPTION
there is a problem but no error message. I think npm is too old