### PR TITLE
Use ark-vrf batch ring verification for tickets

### DIFF
--- a/bandersnatch/Cargo.lock
+++ b/bandersnatch/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bandersnatch-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ark-vrf",
  "getrandom",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "bandersnatch-native"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bandersnatch-core",
  "napi",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "bandersnatch-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bandersnatch-core",
  "getrandom",

--- a/bandersnatch/core/Cargo.toml
+++ b/bandersnatch/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bandersnatch-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/bandersnatch/core/src/lib.rs
+++ b/bandersnatch/core/src/lib.rs
@@ -326,44 +326,59 @@ pub fn batch_generate_ring_vrf_impl(
         .collect()
 }
 
-/// Batch verify multiple tickets.
+/// Batch verify multiple tickets against a single ring.
+///
+/// All tickets are aggregated into a single `ark_vrf::ring::BatchVerifier` and
+/// checked with one amortized pairing + MSM, instead of one pairing per ticket.
+/// Batch verification is inherently all-or-nothing: it yields a single pass/fail
+/// for the whole batch and cannot attribute a failure to a specific ticket.
+///
+/// On success the per-ticket VRF output hashes (entropy) are returned in input
+/// order. The call fails as a whole if the commitment or any signature is
+/// malformed, any VRF input point is invalid, or the batch check does not pass.
 pub fn batch_verify_tickets_impl(
     ring_size: RingSize,
     commitment_bytes: &[u8],
     tickets_data: &[u8],
     vrf_input_data_len: usize,
-) -> Vec<Result<[u8; 32], Error>> {
-    let chunk_size = vrf_input_data_len + RING_SIGNATURE_SIZE;
-    let commitment = match RingCommitment::deserialize_compressed_unchecked(commitment_bytes) {
-        Ok(c) => c,
-        Err(_) => {
-            return tickets_data
-                .chunks(chunk_size)
-                .map(|_| Err(Error::InvalidSignature))
-                .collect();
-        }
-    };
+) -> Result<Vec<[u8; 32]>, Error> {
+    use ark_vrf::ring::BatchVerifier;
 
-    // Build the ring verifier once for the whole batch and reuse it for every
-    // ticket. Construction clones the full `PiopParams` (sized to the ring's
-    // domain, ~2048 for the full ring), so building it per ticket caused
-    // O(ring_size) allocation churn that scaled the memory use with the
-    // validator set and could exhaust memory on a full ring.
+    let commitment = RingCommitment::deserialize_compressed_unchecked(commitment_bytes)
+        .map_err(|_| Error::InvalidSignature)?;
+
+    // Build the ring verifier once for the whole batch. Construction clones the
+    // full `PiopParams` (sized to the ring's domain, ~2048 for the full ring),
+    // so building it per ticket would cause O(ring_size) allocation churn that
+    // scales with the validator set and could exhaust memory on a full ring.
     let verifier = build_ring_verifier(ring_size, commitment);
+    let mut batch = BatchVerifier::new(verifier);
 
-    tickets_data
-        .chunks(chunk_size)
-        .map(|chunk| {
-            if chunk.len() < chunk_size {
-                return Err(Error::InvalidSignature);
-            }
+    let chunk_size = vrf_input_data_len + RING_SIGNATURE_SIZE;
+    let mut entropy = Vec::with_capacity(tickets_data.len() / chunk_size.max(1));
 
-            let signature = &chunk[0..RING_SIGNATURE_SIZE];
-            let vrf_input_data = &chunk[RING_SIGNATURE_SIZE..];
+    for chunk in tickets_data.chunks(chunk_size) {
+        if chunk.len() < chunk_size {
+            return Err(Error::InvalidSignature);
+        }
 
-            Verifier::ring_vrf_verify_with(&verifier, vrf_input_data, &[], signature)
-        })
-        .collect()
+        let signature_bytes = &chunk[0..RING_SIGNATURE_SIZE];
+        let vrf_input_data = &chunk[RING_SIGNATURE_SIZE..];
+
+        let signature = RingVrfSignature::deserialize_compressed_unchecked(signature_bytes)
+            .map_err(|_| Error::InvalidSignature)?;
+        let input = vrf_input_point(vrf_input_data)?;
+        let output = signature.output;
+
+        // The output hash is only trustworthy once the batch verifies; we record
+        // it here and return it only after `batch.verify()` succeeds below.
+        entropy.push(copy_vrf_output_hash(output));
+        batch.push(input, output, &[], &signature.proof);
+    }
+
+    batch.verify().map_err(|_| Error::VerificationFailure)?;
+
+    Ok(entropy)
 }
 
 pub mod ffi {
@@ -516,6 +531,19 @@ pub mod ffi {
         })
     }
 
+    /// Batch verify tickets and encode the result.
+    ///
+    /// Batch verification is all-or-nothing, so the response is a single status
+    /// byte followed by one 32-byte VRF output hash (entropy) per ticket:
+    ///
+    /// - `[RESULT_OK, entropy_0 (32B), entropy_1 (32B), ...]` when every ticket
+    ///   verifies.
+    /// - `[RESULT_ERR, 0u8; num_tickets * 32]` when the batch fails for any
+    ///   reason; the entropy region is zero-filled and must be ignored.
+    ///
+    /// `num_tickets` is derived from the input the same way the caller computes
+    /// it (`tickets_data.len() / (vrf_input_data_len + RING_SIGNATURE_SIZE)`),
+    /// so the response length is identical on success and failure.
     pub fn batch_verify_tickets(
         ring_size: u32,
         commitment: &[u8],
@@ -523,25 +551,28 @@ pub mod ffi {
         vrf_input_data_len: u32,
     ) -> Vec<u8> {
         let ring_size = RingSize::from_size(ring_size as usize);
-        let results = batch_verify_tickets_impl(
+        let chunk_size = vrf_input_data_len as usize + RING_SIGNATURE_SIZE;
+        let num_tickets = tickets_data.len() / chunk_size;
+
+        match batch_verify_tickets_impl(
             ring_size,
             commitment,
             tickets_data,
             vrf_input_data_len as usize,
-        );
-
-        results.into_iter().fold(Vec::new(), |mut acc, result| {
-            match result {
-                Ok(entropy) => {
-                    acc.push(RESULT_OK);
-                    acc.extend(entropy);
+        ) {
+            Ok(entropies) => {
+                let mut result = Vec::with_capacity(1 + entropies.len() * 32);
+                result.push(RESULT_OK);
+                for entropy in entropies {
+                    result.extend_from_slice(&entropy);
                 }
-                Err(_) => {
-                    acc.push(RESULT_ERR);
-                    acc.extend([0u8; 32]);
-                }
+                result
             }
-            acc
-        })
+            Err(_) => {
+                let mut result = vec![RESULT_ERR];
+                result.resize(1 + num_tickets * 32, 0);
+                result
+            }
+        }
     }
 }

--- a/bandersnatch/core/src/test.rs
+++ b/bandersnatch/core/src/test.rs
@@ -256,14 +256,126 @@ mod tests {
             &commitment_bytes,
             &verify_data,
             input_len,
-        );
+        )
+        .expect("batch verification should succeed");
 
         assert_eq!(verify_results.len(), num_inputs as usize);
-        for (i, verify_result) in verify_results.iter().enumerate() {
-            let verified_hash = verify_result.as_ref().expect("verification should succeed");
+        for (i, verified_hash) in verify_results.iter().enumerate() {
             let vrf_input = &inputs_data[i * input_len..(i + 1) * input_len];
             let expected = compute_vrf_output_hash(&seeds[prover_index], vrf_input).unwrap();
             assert_eq!(*verified_hash, expected);
         }
+    }
+
+    /// Build a valid batch of `num_inputs` tickets for the tiny ring and return
+    /// `(commitment_bytes, verify_data, input_len)` ready for batch verification.
+    fn make_valid_batch(num_inputs: u32) -> (Vec<u8>, Vec<u8>, usize) {
+        let (seeds, public_keys) = make_ring(RingSize::Tiny.size());
+        let prover_index = 1;
+        let input_len = 36;
+
+        let mut inputs_data = Vec::new();
+        for attempt in 0..num_inputs {
+            inputs_data.extend_from_slice(&[0xCD; 32]);
+            inputs_data.extend_from_slice(&attempt.to_le_bytes());
+        }
+
+        let results = batch_generate_ring_vrf_impl(
+            &public_keys,
+            prover_index,
+            &seeds[prover_index],
+            &inputs_data,
+            input_len,
+        );
+
+        let commitment_bytes = compute_ring_commitment(&public_keys, RingSize::Tiny).unwrap();
+
+        let mut verify_data = Vec::new();
+        for (i, result) in results.iter().enumerate() {
+            let signature = result.as_ref().unwrap();
+            verify_data.extend_from_slice(signature);
+            verify_data.extend_from_slice(&inputs_data[i * input_len..(i + 1) * input_len]);
+        }
+
+        (commitment_bytes, verify_data, input_len)
+    }
+
+    #[test]
+    fn should_fail_whole_batch_when_one_ticket_is_invalid() {
+        let num_inputs = 3u32;
+        let (commitment_bytes, mut verify_data, input_len) = make_valid_batch(num_inputs);
+
+        // Tamper with the VRF input of the last ticket. The point is still a
+        // valid curve point (hash-to-curve), so this exercises the batch
+        // verification failure path rather than a deserialization error.
+        let last = verify_data.len() - 1;
+        verify_data[last] ^= 0xFF;
+
+        let result = crate::batch_verify_tickets_impl(
+            RingSize::Tiny,
+            &commitment_bytes,
+            &verify_data,
+            input_len,
+        );
+
+        // All-or-nothing: a single bad ticket fails the entire batch.
+        assert_eq!(result, Err(crate::Error::VerificationFailure));
+    }
+
+    #[test]
+    fn should_fail_batch_with_invalid_commitment() {
+        let (_commitment_bytes, verify_data, input_len) = make_valid_batch(2);
+        let bad_commitment = [0xAB; 16];
+
+        let result = crate::batch_verify_tickets_impl(
+            RingSize::Tiny,
+            &bad_commitment,
+            &verify_data,
+            input_len,
+        );
+
+        assert_eq!(result, Err(crate::Error::InvalidSignature));
+    }
+
+    #[test]
+    fn should_encode_batch_verify_ffi_wire_format() {
+        const RESULT_OK: u8 = 0;
+        const RESULT_ERR: u8 = 1;
+
+        let num_inputs = 3u32;
+        let (commitment_bytes, verify_data, input_len) = make_valid_batch(num_inputs);
+
+        // Success: status byte + one 32-byte entropy hash per ticket.
+        let ok = crate::ffi::batch_verify_tickets(
+            RingSize::Tiny.size() as u32,
+            &commitment_bytes,
+            &verify_data,
+            input_len as u32,
+        );
+        assert_eq!(ok[0], RESULT_OK);
+        assert_eq!(ok.len(), 1 + num_inputs as usize * 32);
+
+        // The encoded hashes must match the impl's returned entropy in order.
+        let expected = crate::batch_verify_tickets_impl(
+            RingSize::Tiny,
+            &commitment_bytes,
+            &verify_data,
+            input_len,
+        )
+        .unwrap();
+        for (i, hash) in expected.iter().enumerate() {
+            assert_eq!(&ok[1 + i * 32..1 + (i + 1) * 32], hash.as_slice());
+        }
+
+        // Failure: same length, status byte ERR, zero-filled entropy region.
+        let err = crate::ffi::batch_verify_tickets(
+            RingSize::Tiny.size() as u32,
+            &[0xAB; 16],
+            &verify_data,
+            input_len as u32,
+        );
+        assert_eq!(err[0], RESULT_ERR);
+        assert_eq!(err.len(), 1 + num_inputs as usize * 32);
+        assert!(err[1..].iter().all(|&b| b == 0));
     }
 }

--- a/bandersnatch/native-binding/Cargo.toml
+++ b/bandersnatch/native-binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bandersnatch-native"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [lib]

--- a/bandersnatch/npm/darwin-arm64/package.json
+++ b/bandersnatch/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeberry/bandersnatch-native-darwin-arm64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Native Node.js bindings for Bandersnatch VRF - darwin-arm64 platform",
   "main": "./bandersnatch.darwin-arm64.node",
   "os": ["darwin"],

--- a/bandersnatch/npm/linux-x64-gnu/package.json
+++ b/bandersnatch/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeberry/bandersnatch-native-linux-x64-gnu",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Native Node.js bindings for Bandersnatch VRF - linux-x64-gnu platform",
   "main": "./bandersnatch.linux-x64-gnu.node",
   "os": ["linux"],

--- a/bandersnatch/package.json
+++ b/bandersnatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeberry/bandersnatch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Bandersnatch VRF library - auto-detects native bindings for Node.js with WASM fallback for browsers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -35,8 +35,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@typeberry/bandersnatch-native-darwin-arm64": "0.3.0",
-    "@typeberry/bandersnatch-native-linux-x64-gnu": "0.3.0"
+    "@typeberry/bandersnatch-native-darwin-arm64": "0.4.0",
+    "@typeberry/bandersnatch-native-linux-x64-gnu": "0.4.0"
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/bandersnatch/src/index.ts
+++ b/bandersnatch/src/index.ts
@@ -235,6 +235,24 @@ export function batchGenerateRingVrf(
   );
 }
 
+/**
+ * Batch-verify ring VRF tickets against a single ring commitment.
+ *
+ * Verification is all-or-nothing: every ticket is aggregated into one batched
+ * pairing check, so the result reports a single pass/fail for the whole batch
+ * (an individual failing ticket cannot be identified).
+ *
+ * `ticketsData` is the concatenation of `signature (784 bytes) || vrfInput
+ * (vrfInputDataLen bytes)` per ticket. The returned buffer is:
+ *
+ * - On success: `[0x00, entropyHash_0 (32B), entropyHash_1 (32B), ...]` — the
+ *   status byte followed by one VRF output hash per ticket, in input order.
+ * - On failure: `[0x01, 0x00 * (numTickets * 32)]` — the status byte followed
+ *   by a zero-filled region of the same length; the hashes must be ignored.
+ *
+ * `numTickets` equals `ticketsData.length / (vrfInputDataLen + 784)`, so the
+ * response length is identical for success and failure.
+ */
 export function batchVerifyTickets(
   ringSize: number,
   commitment: Uint8Array,

--- a/bandersnatch/wasm-binding/Cargo.toml
+++ b/bandersnatch/wasm-binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bandersnatch-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeberry/native",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Native libraries for typeberry - bundles bandersnatch, ed25519 and reed-solomon with WASM and optional native bindings",
   "main": "./index.js",
   "types": "./index.d.ts",
@@ -23,8 +23,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@typeberry/bandersnatch-native-darwin-arm64": "0.3.0",
-    "@typeberry/bandersnatch-native-linux-x64-gnu": "0.3.0"
+    "@typeberry/bandersnatch-native-darwin-arm64": "0.4.0",
+    "@typeberry/bandersnatch-native-linux-x64-gnu": "0.4.0"
   },
   "scripts": {
     "lint": "true",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typeberry/native-workspace",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typeberry/native-workspace",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "workspaces": [
         "bandersnatch",
@@ -26,13 +26,13 @@
         "npm": ">=10"
       },
       "optionalDependencies": {
-        "@typeberry/bandersnatch-native-darwin-arm64": "0.3.0",
-        "@typeberry/bandersnatch-native-linux-x64-gnu": "0.3.0"
+        "@typeberry/bandersnatch-native-darwin-arm64": "0.4.0",
+        "@typeberry/bandersnatch-native-linux-x64-gnu": "0.4.0"
       }
     },
     "bandersnatch": {
       "name": "@typeberry/bandersnatch",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "typescript": "^5.6.3"
@@ -41,13 +41,13 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@typeberry/bandersnatch-native-darwin-arm64": "0.3.0",
-        "@typeberry/bandersnatch-native-linux-x64-gnu": "0.3.0"
+        "@typeberry/bandersnatch-native-darwin-arm64": "0.4.0",
+        "@typeberry/bandersnatch-native-linux-x64-gnu": "0.4.0"
       }
     },
     "bandersnatch/npm/darwin-arm64": {
       "name": "@typeberry/bandersnatch-native-darwin-arm64",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "cpu": [
         "arm64"
       ],
@@ -62,7 +62,7 @@
     },
     "bandersnatch/npm/linux-x64-gnu": {
       "name": "@typeberry/bandersnatch-native-linux-x64-gnu",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "cpu": [
         "x64"
       ],
@@ -98,14 +98,14 @@
     },
     "native": {
       "name": "@typeberry/native",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@typeberry/bandersnatch-native-darwin-arm64": "0.3.0",
-        "@typeberry/bandersnatch-native-linux-x64-gnu": "0.3.0"
+        "@typeberry/bandersnatch-native-darwin-arm64": "0.4.0",
+        "@typeberry/bandersnatch-native-linux-x64-gnu": "0.4.0"
       }
     },
     "node_modules/@babel/generator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeberry/native-workspace",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Native libraries for typeberry.",
   "workspaces": [
     "bandersnatch",
@@ -19,8 +19,8 @@
   "author": "Fluffy Labs",
   "license": "MPL-2.0",
   "optionalDependencies": {
-    "@typeberry/bandersnatch-native-darwin-arm64": "0.3.0",
-    "@typeberry/bandersnatch-native-linux-x64-gnu": "0.3.0"
+    "@typeberry/bandersnatch-native-darwin-arm64": "0.4.0",
+    "@typeberry/bandersnatch-native-linux-x64-gnu": "0.4.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.1.5",


### PR DESCRIPTION
## Summary

Switches ticket verification to ark-vrf's batched ring API. `batch_verify_tickets_impl` now aggregates every ticket into a single `ark_vrf::ring::BatchVerifier` and runs **one amortized pairing + MSM** instead of one `Public::verify` per ticket. The ring verifier is still built once per batch (preserving the earlier "Reuse verifier" memory fix).

**Stays on the already-pinned ark-vrf 0.2.2.** The batch verification API has existed since 0.2.0 — it was *not* introduced in a newer version. Bumping to the latest 0.5.0 would have been a draft-33 cryptographic break (regenerated base points / suite IDs / test vectors; old tickets would no longer verify), so it was deliberately avoided.

## Behavior change (breaking)

Batch verification is inherently **all-or-nothing**: it yields a single pass/fail for the whole batch and cannot attribute a failure to a specific ticket. On success, every ticket's VRF output hash (`entropyHash`) is still returned, in input order.

The impl return type changes from `Vec<Result<[u8;32], Error>>` (per-ticket) to `Result<Vec<[u8;32]>, Error>`.

### New FFI / wire format
- **Success:** `[0x00, entropy_0 (32B), entropy_1 (32B), ...]`
- **Failure:** `[0x01, 0x00 × (numTickets * 32)]` — zero-filled, ignore the hashes

`numTickets = ticketsData.length / (vrfInputDataLen + 784)`, so the response length is identical for success and failure.

## Consumer follow-ups (not in this repo)
- **typeberry must update its parser** of the returned `Uint8Array` to read `[status][N×32]` instead of the old `[status,32]×N`.
- Per-ticket attribution on failure is gone by design; any caller needing to drop individual bad tickets (e.g. mempool gossip) must re-verify one-by-one to find the culprit.
- The native/WASM binding **artifacts must be rebuilt/republished** for the new format to reach consumers.

## Tests
All 14 Rust tests pass; clippy clean; workspace builds. Added coverage for: success path, whole-batch failure on one bad ticket, invalid commitment, and the FFI wire format. Documented the new contract on the TS `batchVerifyTickets`.

## Version
Bumps `0.3.0` → `0.4.0` (minor bump for a breaking change on 0.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)