### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         run: npm run build:native --workspaces --if-present -- ${{ matrix.settings.target }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: bandersnatch/npm/*/*.node

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build WASM library
         run: npm run build --workspaces --if-present
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-build
           path: |
@@ -61,7 +61,7 @@ jobs:
       - name: Build
         run: npm run build:native --workspaces --if-present -- ${{ matrix.settings.target }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: bandersnatch/npm/${{ matrix.settings.package }}/*.node
@@ -85,19 +85,19 @@ jobs:
         run: npm ci
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-build
           path: .
 
       - name: Download darwin-arm64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-aarch64-apple-darwin
           path: bandersnatch/npm/darwin-arm64/
 
       - name: Download linux-x64-gnu native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: bandersnatch/npm/linux-x64-gnu/
@@ -106,7 +106,7 @@ jobs:
         run: npm run build
 
       - id: vars
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Update versions
         run: |


### PR DESCRIPTION
## Summary
- bump artifact upload actions to v7
- bump artifact download actions to v8
- quote GITHUB_OUTPUT in publish workflow for actionlint

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/publish.yml