### PR TITLE
Add Bandersnatch ticket generation APIs

### DIFF
--- a/bandersnatch/core/src/lib.rs
+++ b/bandersnatch/core/src/lib.rs
@@ -8,7 +8,7 @@ use ark_vrf::reexports::ark_serialize::{self, CanonicalDeserialize, CanonicalSer
 use ark_vrf::suites::bandersnatch;
 use bandersnatch::{
     BandersnatchSha512Ell2, IetfProof, Input, Output, Public, RingProof, RingProofParams,
-    RingVerifier, Secret,
+    RingProver, RingVerifier, Secret,
 };
 
 #[cfg(test)]
@@ -290,6 +290,69 @@ pub fn verify_seal_impl(
     Verifier::ietf_vrf_verify(payload, aux_data, seal_data, public_key)
 }
 
+fn input_chunk_count(inputs_data: &[u8], vrf_input_data_len: usize) -> usize {
+    if vrf_input_data_len == 0 {
+        return 1;
+    }
+    inputs_data.len().div_ceil(vrf_input_data_len)
+}
+
+fn ring_vrf_error_results(count: usize, error: Error) -> Vec<Result<Vec<u8>, Error>> {
+    vec![Err(error); count]
+}
+
+fn generate_ring_vrf_signatures_with_prover(
+    secret: &Secret,
+    prover: &RingProver,
+    inputs_data: &[u8],
+    vrf_input_data_len: usize,
+) -> Vec<Result<Vec<u8>, Error>> {
+    if vrf_input_data_len == 0 {
+        return ring_vrf_error_results(1, Error::InvalidPointData);
+    }
+
+    inputs_data
+        .chunks(vrf_input_data_len)
+        .map(|vrf_input_data| {
+            if vrf_input_data.len() < vrf_input_data_len {
+                return Err(Error::InvalidPointData);
+            }
+
+            let input = vrf_input_point(vrf_input_data)?;
+            let output = secret.output(input);
+
+            let proof = ark_vrf::ring::Prover::prove(secret, input, output, &[], prover);
+
+            let sig = RingVrfSignature { output, proof };
+            let mut signature = Vec::new();
+            sig.serialize_compressed(&mut signature)
+                .map_err(|_| Error::InvalidSignature)?;
+            Ok(signature)
+        })
+        .collect()
+}
+
+/// Generate one anonymous ring VRF signature for a concrete input.
+///
+/// Callers that model ticket attempts in the input bytes can use this to
+/// generate an exact attempt, instead of generating the whole `0..X` range.
+pub fn generate_ring_vrf_impl(
+    ring_keys: &[Public],
+    prover_key_index: usize,
+    secret_seed: &[u8],
+    vrf_input_data: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let mut results = batch_generate_ring_vrf_impl(
+        ring_keys,
+        prover_key_index,
+        secret_seed,
+        vrf_input_data,
+        vrf_input_data.len(),
+    );
+
+    results.pop().unwrap_or(Err(Error::InvalidPointData))
+}
+
 /// Batch generate anonymous ring VRF signatures.
 pub fn batch_generate_ring_vrf_impl(
     ring_keys: &[Public],
@@ -302,28 +365,72 @@ pub fn batch_generate_ring_vrf_impl(
     let secret = Secret::from_seed(secret_seed);
     let ring_params = ring_proof_params(ring_size);
     let pts: Vec<_> = ring_keys.iter().map(|pk| pk.0).collect();
+    let num_inputs = input_chunk_count(inputs_data, vrf_input_data_len);
 
-    inputs_data
-        .chunks(vrf_input_data_len)
-        .map(|vrf_input_data| {
-            if vrf_input_data.len() < vrf_input_data_len {
-                return Err(Error::InvalidPointData);
-            }
+    if prover_key_index >= ring_keys.len() {
+        return ring_vrf_error_results(num_inputs, Error::InvalidSignature);
+    }
 
-            let input = vrf_input_point(vrf_input_data)?;
-            let output = secret.output(input);
+    let prover_key = ring_params.prover_key(&pts);
+    let prover = ring_params.prover(prover_key, prover_key_index);
 
-            let prover_key = ring_params.prover_key(&pts);
-            let prover = ring_params.prover(prover_key, prover_key_index);
-            let proof = ark_vrf::ring::Prover::prove(&secret, input, output, &[], &prover);
+    generate_ring_vrf_signatures_with_prover(&secret, &prover, inputs_data, vrf_input_data_len)
+}
 
-            let sig = RingVrfSignature { output, proof };
-            let mut signature = Vec::new();
-            sig.serialize_compressed(&mut signature)
-                .map_err(|_| Error::InvalidSignature)?;
-            Ok(signature)
-        })
-        .collect()
+/// Batch generate anonymous ring VRF signatures for multiple validators.
+///
+/// Results are returned validator-major, then input-major:
+/// `validator_0/input_0`, `validator_0/input_1`, ..., `validator_1/input_0`, ...
+///
+/// This reuses the ring prover key across validators and reuses each validator's
+/// prover across all inputs, so it avoids the setup churn of calling
+/// [`batch_generate_ring_vrf_impl`] once per validator.
+pub fn batch_generate_ring_vrf_for_validators_impl(
+    ring_keys: &[Public],
+    prover_key_indices: &[usize],
+    secret_seeds: &[&[u8]],
+    inputs_data: &[u8],
+    vrf_input_data_len: usize,
+) -> Result<Vec<Result<Vec<u8>, Error>>, Error> {
+    if prover_key_indices.len() != secret_seeds.len() {
+        return Err(Error::InvalidSignature);
+    }
+
+    if prover_key_indices.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let num_inputs = input_chunk_count(inputs_data, vrf_input_data_len);
+    if ring_keys.is_empty() {
+        return Ok(ring_vrf_error_results(
+            prover_key_indices.len() * num_inputs,
+            Error::InvalidSignature,
+        ));
+    }
+
+    let ring_size = RingSize::from_size(ring_keys.len());
+    let ring_params = ring_proof_params(ring_size);
+    let pts: Vec<_> = ring_keys.iter().map(|pk| pk.0).collect();
+    let prover_key = ring_params.prover_key(&pts);
+
+    let mut results = Vec::with_capacity(prover_key_indices.len() * num_inputs);
+    for (&prover_key_index, secret_seed) in prover_key_indices.iter().zip(secret_seeds.iter()) {
+        if prover_key_index >= ring_keys.len() {
+            results.extend(ring_vrf_error_results(num_inputs, Error::InvalidSignature));
+            continue;
+        }
+
+        let secret = Secret::from_seed(secret_seed);
+        let prover = ring_params.prover(prover_key.clone(), prover_key_index);
+        results.extend(generate_ring_vrf_signatures_with_prover(
+            &secret,
+            &prover,
+            inputs_data,
+            vrf_input_data_len,
+        ));
+    }
+
+    Ok(results)
 }
 
 /// Batch verify multiple tickets against a single ring.
@@ -496,6 +603,56 @@ pub mod ffi {
         }
     }
 
+    fn encode_ring_vrf_generation_results(results: Vec<Result<Vec<u8>, Error>>) -> Vec<u8> {
+        results.into_iter().fold(Vec::new(), |mut acc, result| {
+            match result {
+                Ok(signature) => {
+                    acc.push(RESULT_OK);
+                    acc.extend_from_slice(&signature);
+                }
+                Err(_) => {
+                    acc.push(RESULT_ERR);
+                    acc.extend([0u8; RING_SIGNATURE_SIZE]);
+                }
+            }
+            acc
+        })
+    }
+
+    fn decode_prover_key_indices(prover_key_indices: &[u8]) -> Result<Vec<usize>, Error> {
+        if prover_key_indices.len() % 4 != 0 {
+            return Err(Error::InvalidSignature);
+        }
+
+        Ok(prover_key_indices
+            .chunks_exact(4)
+            .map(|chunk| {
+                u32::from_le_bytes(chunk.try_into().expect("chunk length checked")) as usize
+            })
+            .collect())
+    }
+
+    pub fn generate_ring_vrf(
+        ring_keys: &[u8],
+        prover_key_index: u32,
+        secret_seed: &[u8],
+        vrf_input_data: &[u8],
+    ) -> Vec<u8> {
+        let public_keys: Vec<_> = ring_keys
+            .chunks(PUBLIC_KEY_SIZE)
+            .map(deserialize_public_key)
+            .collect();
+
+        let result = generate_ring_vrf_impl(
+            &public_keys,
+            prover_key_index as usize,
+            secret_seed,
+            vrf_input_data,
+        );
+
+        encode_ring_vrf_generation_results(vec![result])
+    }
+
     pub fn batch_generate_ring_vrf(
         ring_keys: &[u8],
         prover_key_index: u32,
@@ -516,19 +673,49 @@ pub mod ffi {
             vrf_input_data_len as usize,
         );
 
-        results.into_iter().fold(Vec::new(), |mut acc, result| {
-            match result {
-                Ok(signature) => {
-                    acc.push(RESULT_OK);
-                    acc.extend_from_slice(&signature);
-                }
-                Err(_) => {
-                    acc.push(RESULT_ERR);
-                    acc.extend([0u8; RING_SIGNATURE_SIZE]);
-                }
-            }
-            acc
-        })
+        encode_ring_vrf_generation_results(results)
+    }
+
+    pub fn batch_generate_ring_vrf_for_validators(
+        ring_keys: &[u8],
+        prover_key_indices: &[u8],
+        secret_seeds_data: &[u8],
+        secret_seed_data_len: u32,
+        inputs_data: &[u8],
+        vrf_input_data_len: u32,
+    ) -> Vec<u8> {
+        let secret_seed_data_len = secret_seed_data_len as usize;
+        if secret_seed_data_len == 0 || secret_seeds_data.len() % secret_seed_data_len != 0 {
+            return vec![RESULT_ERR];
+        }
+
+        let prover_key_indices = match decode_prover_key_indices(prover_key_indices) {
+            Ok(indices) => indices,
+            Err(_) => return vec![RESULT_ERR],
+        };
+
+        let secret_seeds: Vec<_> = secret_seeds_data.chunks(secret_seed_data_len).collect();
+        if prover_key_indices.len() != secret_seeds.len() {
+            return vec![RESULT_ERR];
+        }
+
+        let public_keys: Vec<_> = ring_keys
+            .chunks(PUBLIC_KEY_SIZE)
+            .map(deserialize_public_key)
+            .collect();
+
+        let results = match batch_generate_ring_vrf_for_validators_impl(
+            &public_keys,
+            &prover_key_indices,
+            &secret_seeds,
+            inputs_data,
+            vrf_input_data_len as usize,
+        ) {
+            Ok(results) => results,
+            Err(_) => return vec![RESULT_ERR],
+        };
+
+        encode_ring_vrf_generation_results(results)
     }
 
     /// Batch verify tickets and encode the result.

--- a/bandersnatch/core/src/test.rs
+++ b/bandersnatch/core/src/test.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        RingSize, batch_generate_ring_vrf_impl, compute_ring_commitment, compute_vrf_output_hash,
+        RING_SIGNATURE_SIZE, RingSize, batch_generate_ring_vrf_for_validators_impl,
+        batch_generate_ring_vrf_impl, compute_ring_commitment, compute_vrf_output_hash,
         derive_public_key_from_seed, deserialize_public_key, generate_ietf_seal,
-        verify_header_seals_impl, verify_seal_impl,
+        generate_ring_vrf_impl, verify_header_seals_impl, verify_seal_impl,
     };
 
     #[test]
@@ -265,6 +266,164 @@ mod tests {
             let expected = compute_vrf_output_hash(&seeds[prover_index], vrf_input).unwrap();
             assert_eq!(*verified_hash, expected);
         }
+    }
+
+    #[test]
+    fn should_generate_specific_ring_vrf_attempt() {
+        let (seeds, public_keys) = make_ring(RingSize::Tiny.size());
+        let prover_index = 1;
+        let input_len = 36;
+        let attempt = 7u32;
+
+        let mut vrf_input = Vec::new();
+        vrf_input.extend_from_slice(&[0xCD; 32]);
+        vrf_input.extend_from_slice(&attempt.to_le_bytes());
+
+        let signature =
+            generate_ring_vrf_impl(&public_keys, prover_index, &seeds[prover_index], &vrf_input)
+                .unwrap();
+
+        let commitment_bytes = compute_ring_commitment(&public_keys, RingSize::Tiny).unwrap();
+        let mut verify_data = Vec::new();
+        verify_data.extend_from_slice(&signature);
+        verify_data.extend_from_slice(&vrf_input);
+
+        let verify_results = crate::batch_verify_tickets_impl(
+            RingSize::Tiny,
+            &commitment_bytes,
+            &verify_data,
+            input_len,
+        )
+        .expect("single-attempt ticket should verify");
+
+        let expected = compute_vrf_output_hash(&seeds[prover_index], &vrf_input).unwrap();
+        assert_eq!(verify_results, vec![expected]);
+    }
+
+    #[test]
+    fn should_batch_generate_for_multiple_validators() {
+        let (seeds, public_keys) = make_ring(RingSize::Tiny.size());
+        let prover_indices = vec![1usize, 3usize];
+        let secret_seeds: Vec<&[u8]> = prover_indices
+            .iter()
+            .map(|&index| seeds[index].as_slice())
+            .collect();
+        let input_len = 36;
+        let num_inputs = 2u32;
+
+        let mut inputs_data = Vec::new();
+        for attempt in 0..num_inputs {
+            inputs_data.extend_from_slice(&[0xCD; 32]);
+            inputs_data.extend_from_slice(&attempt.to_le_bytes());
+        }
+
+        let results = batch_generate_ring_vrf_for_validators_impl(
+            &public_keys,
+            &prover_indices,
+            &secret_seeds,
+            &inputs_data,
+            input_len,
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), prover_indices.len() * num_inputs as usize);
+
+        let commitment_bytes = compute_ring_commitment(&public_keys, RingSize::Tiny).unwrap();
+        let mut verify_data = Vec::new();
+        for validator_offset in 0..prover_indices.len() {
+            for input_offset in 0..num_inputs as usize {
+                let result_offset = validator_offset * num_inputs as usize + input_offset;
+                let signature = results[result_offset].as_ref().unwrap();
+                verify_data.extend_from_slice(signature);
+                verify_data.extend_from_slice(
+                    &inputs_data[input_offset * input_len..(input_offset + 1) * input_len],
+                );
+            }
+        }
+
+        let verify_results = crate::batch_verify_tickets_impl(
+            RingSize::Tiny,
+            &commitment_bytes,
+            &verify_data,
+            input_len,
+        )
+        .expect("multi-validator tickets should verify");
+
+        for (validator_offset, &prover_index) in prover_indices.iter().enumerate() {
+            for input_offset in 0..num_inputs as usize {
+                let result_offset = validator_offset * num_inputs as usize + input_offset;
+                let vrf_input =
+                    &inputs_data[input_offset * input_len..(input_offset + 1) * input_len];
+                let expected = compute_vrf_output_hash(&seeds[prover_index], vrf_input).unwrap();
+                assert_eq!(verify_results[result_offset], expected);
+            }
+        }
+    }
+
+    #[test]
+    fn should_encode_multi_validator_batch_generation_ffi_wire_format() {
+        const RESULT_OK: u8 = 0;
+
+        let (seeds, public_keys) = make_ring(RingSize::Tiny.size());
+        let prover_indices = [1u32, 3u32];
+        let input_len = 36;
+        let num_inputs = 2u32;
+
+        let mut ring_keys = Vec::new();
+        for seed in &seeds {
+            ring_keys.extend_from_slice(&derive_public_key_from_seed(seed).unwrap());
+        }
+
+        let mut prover_key_indices_data = Vec::new();
+        for index in prover_indices {
+            prover_key_indices_data.extend_from_slice(&index.to_le_bytes());
+        }
+
+        let mut secret_seeds_data = Vec::new();
+        secret_seeds_data.extend_from_slice(&seeds[1]);
+        secret_seeds_data.extend_from_slice(&seeds[3]);
+
+        let mut inputs_data = Vec::new();
+        for attempt in 0..num_inputs {
+            inputs_data.extend_from_slice(&[0xCD; 32]);
+            inputs_data.extend_from_slice(&attempt.to_le_bytes());
+        }
+
+        let encoded = crate::ffi::batch_generate_ring_vrf_for_validators(
+            &ring_keys,
+            &prover_key_indices_data,
+            &secret_seeds_data,
+            seeds[1].len() as u32,
+            &inputs_data,
+            input_len as u32,
+        );
+
+        assert_eq!(
+            encoded.len(),
+            prover_indices.len() * num_inputs as usize * (1 + RING_SIGNATURE_SIZE)
+        );
+        for record in encoded.chunks(1 + RING_SIGNATURE_SIZE) {
+            assert_eq!(record[0], RESULT_OK);
+            assert_ne!(&record[1..], &[0u8; RING_SIGNATURE_SIZE]);
+        }
+
+        let commitment_bytes = compute_ring_commitment(&public_keys, RingSize::Tiny).unwrap();
+        let mut verify_data = Vec::new();
+        for (record_index, record) in encoded.chunks(1 + RING_SIGNATURE_SIZE).enumerate() {
+            let input_offset = record_index % num_inputs as usize;
+            verify_data.extend_from_slice(&record[1..]);
+            verify_data.extend_from_slice(
+                &inputs_data[input_offset * input_len..(input_offset + 1) * input_len],
+            );
+        }
+
+        crate::batch_verify_tickets_impl(
+            RingSize::Tiny,
+            &commitment_bytes,
+            &verify_data,
+            input_len,
+        )
+        .expect("encoded multi-validator tickets should verify");
     }
 
     /// Build a valid batch of `num_inputs` tickets for the tiny ring and return

--- a/bandersnatch/native-binding/src/lib.rs
+++ b/bandersnatch/native-binding/src/lib.rs
@@ -59,6 +59,22 @@ pub fn vrf_output_hash(secret_seed: Buffer, input: Buffer) -> Buffer {
 }
 
 #[napi]
+pub fn generate_ring_vrf(
+    ring_keys: Buffer,
+    prover_key_index: u32,
+    secret_seed: Buffer,
+    vrf_input_data: Buffer,
+) -> Buffer {
+    ffi::generate_ring_vrf(
+        ring_keys.as_ref(),
+        prover_key_index,
+        secret_seed.as_ref(),
+        vrf_input_data.as_ref(),
+    )
+    .into()
+}
+
+#[napi]
 pub fn batch_generate_ring_vrf(
     ring_keys: Buffer,
     prover_key_index: u32,
@@ -70,6 +86,26 @@ pub fn batch_generate_ring_vrf(
         ring_keys.as_ref(),
         prover_key_index,
         secret_seed.as_ref(),
+        inputs_data.as_ref(),
+        vrf_input_data_len,
+    )
+    .into()
+}
+
+#[napi]
+pub fn batch_generate_ring_vrf_for_validators(
+    ring_keys: Buffer,
+    prover_key_indices: Buffer,
+    secret_seeds_data: Buffer,
+    secret_seed_data_len: u32,
+    inputs_data: Buffer,
+    vrf_input_data_len: u32,
+) -> Buffer {
+    ffi::batch_generate_ring_vrf_for_validators(
+        ring_keys.as_ref(),
+        prover_key_indices.as_ref(),
+        secret_seeds_data.as_ref(),
+        secret_seed_data_len,
         inputs_data.as_ref(),
         vrf_input_data_len,
     )

--- a/bandersnatch/src/index.ts
+++ b/bandersnatch/src/index.ts
@@ -56,10 +56,24 @@ export type BandersnatchApi = {
   ) => Uint8Array;
   generateSeal: (secretSeed: Uint8Array, input: Uint8Array, auxData: Uint8Array) => Uint8Array;
   vrfOutputHash: (secretSeed: Uint8Array, input: Uint8Array) => Uint8Array;
+  generateRingVrf: (
+    ringKeys: Uint8Array,
+    proverKeyIndex: number,
+    secretSeed: Uint8Array,
+    vrfInputData: Uint8Array
+  ) => Uint8Array;
   batchGenerateRingVrf: (
     ringKeys: Uint8Array,
     proverKeyIndex: number,
     secretSeed: Uint8Array,
+    inputsData: Uint8Array,
+    vrfInputDataLen: number
+  ) => Uint8Array;
+  batchGenerateRingVrfForValidators: (
+    ringKeys: Uint8Array,
+    proverKeyIndices: Uint32Array | readonly number[],
+    secretSeedsData: Uint8Array,
+    secretSeedDataLen: number,
     inputsData: Uint8Array,
     vrfInputDataLen: number
   ) => Uint8Array;
@@ -80,7 +94,9 @@ function createApi(): BandersnatchApi {
     verifySeal,
     generateSeal,
     vrfOutputHash,
+    generateRingVrf,
     batchGenerateRingVrf,
+    batchGenerateRingVrfForValidators,
     batchVerifyTickets,
   };
 }
@@ -209,6 +225,26 @@ export function vrfOutputHash(secretSeed: Uint8Array, input: Uint8Array): Uint8A
   return wasmBinding!.vrf_output_hash(secretSeed, input);
 }
 
+/**
+ * Generate one ring VRF ticket for a concrete VRF input.
+ *
+ * This is the single-attempt form of `batchGenerateRingVrf`: callers encode the
+ * desired attempt into `vrfInputData` and receive one `status || signature`
+ * record, where the signature is 784 bytes.
+ */
+export function generateRingVrf(
+  ringKeys: Uint8Array,
+  proverKeyIndex: number,
+  secretSeed: Uint8Array,
+  vrfInputData: Uint8Array
+): Uint8Array {
+  assertInitialized();
+  if (nativeBinding) {
+    return nativeBinding.generateRingVrf(ringKeys, proverKeyIndex, secretSeed, vrfInputData);
+  }
+  return wasmBinding!.generate_ring_vrf(ringKeys, proverKeyIndex, secretSeed, vrfInputData);
+}
+
 export function batchGenerateRingVrf(
   ringKeys: Uint8Array,
   proverKeyIndex: number,
@@ -230,6 +266,62 @@ export function batchGenerateRingVrf(
     ringKeys,
     proverKeyIndex,
     secretSeed,
+    inputsData,
+    vrfInputDataLen
+  );
+}
+
+function encodeProverKeyIndices(indices: Uint32Array | readonly number[]): Uint8Array {
+  const result = new Uint8Array(indices.length * 4);
+  const view = new DataView(result.buffer, result.byteOffset, result.byteLength);
+
+  for (let i = 0; i < indices.length; i++) {
+    const index = indices[i];
+    if (!Number.isInteger(index) || index < 0 || index > 0xffffffff) {
+      throw new RangeError(`Invalid prover key index at position ${i}: ${index}`);
+    }
+    view.setUint32(i * 4, index, true);
+  }
+
+  return result;
+}
+
+/**
+ * Batch-generate ring VRF tickets for multiple validators.
+ *
+ * `secretSeedsData` is fixed-width concatenated seed data, split by
+ * `secretSeedDataLen`. `proverKeyIndices` and secret seeds must have the same
+ * count. The returned records are ordered validator-major, then input-major:
+ * `validator_0/input_0`, `validator_0/input_1`, ..., `validator_1/input_0`, ...
+ *
+ * Each record is `status byte || signature (784 bytes)`. If the validator
+ * metadata is malformed, the function returns a single error status byte.
+ */
+export function batchGenerateRingVrfForValidators(
+  ringKeys: Uint8Array,
+  proverKeyIndices: Uint32Array | readonly number[],
+  secretSeedsData: Uint8Array,
+  secretSeedDataLen: number,
+  inputsData: Uint8Array,
+  vrfInputDataLen: number
+): Uint8Array {
+  assertInitialized();
+  const proverKeyIndicesData = encodeProverKeyIndices(proverKeyIndices);
+  if (nativeBinding) {
+    return nativeBinding.batchGenerateRingVrfForValidators(
+      ringKeys,
+      proverKeyIndicesData,
+      secretSeedsData,
+      secretSeedDataLen,
+      inputsData,
+      vrfInputDataLen
+    );
+  }
+  return wasmBinding!.batch_generate_ring_vrf_for_validators(
+    ringKeys,
+    proverKeyIndicesData,
+    secretSeedsData,
+    secretSeedDataLen,
     inputsData,
     vrfInputDataLen
   );

--- a/bandersnatch/src/native.ts
+++ b/bandersnatch/src/native.ts
@@ -19,10 +19,24 @@ export interface NativeBinding {
   ) => Uint8Array;
   generateSeal: (secretSeed: Uint8Array, input: Uint8Array, auxData: Uint8Array) => Uint8Array;
   vrfOutputHash: (secretSeed: Uint8Array, input: Uint8Array) => Uint8Array;
+  generateRingVrf: (
+    ringKeys: Uint8Array,
+    proverKeyIndex: number,
+    secretSeed: Uint8Array,
+    vrfInputData: Uint8Array
+  ) => Uint8Array;
   batchGenerateRingVrf: (
     ringKeys: Uint8Array,
     proverKeyIndex: number,
     secretSeed: Uint8Array,
+    inputsData: Uint8Array,
+    vrfInputDataLen: number
+  ) => Uint8Array;
+  batchGenerateRingVrfForValidators: (
+    ringKeys: Uint8Array,
+    proverKeyIndices: Uint8Array,
+    secretSeedsData: Uint8Array,
+    secretSeedDataLen: number,
     inputsData: Uint8Array,
     vrfInputDataLen: number
   ) => Uint8Array;
@@ -72,4 +86,3 @@ export async function loadNativeBinding(): Promise<NativeBinding> {
 
   return nativeBinding;
 }
-

--- a/bandersnatch/wasm-binding/src/lib.rs
+++ b/bandersnatch/wasm-binding/src/lib.rs
@@ -51,6 +51,16 @@ pub fn vrf_output_hash(secret_seed: &[u8], input: &[u8]) -> Vec<u8> {
 }
 
 #[wasm_bindgen]
+pub fn generate_ring_vrf(
+    ring_keys: &[u8],
+    prover_key_index: u32,
+    secret_seed: &[u8],
+    vrf_input_data: &[u8],
+) -> Vec<u8> {
+    ffi::generate_ring_vrf(ring_keys, prover_key_index, secret_seed, vrf_input_data)
+}
+
+#[wasm_bindgen]
 pub fn batch_generate_ring_vrf(
     ring_keys: &[u8],
     prover_key_index: u32,
@@ -62,6 +72,25 @@ pub fn batch_generate_ring_vrf(
         ring_keys,
         prover_key_index,
         secret_seed,
+        inputs_data,
+        vrf_input_data_len,
+    )
+}
+
+#[wasm_bindgen]
+pub fn batch_generate_ring_vrf_for_validators(
+    ring_keys: &[u8],
+    prover_key_indices: &[u8],
+    secret_seeds_data: &[u8],
+    secret_seed_data_len: u32,
+    inputs_data: &[u8],
+    vrf_input_data_len: u32,
+) -> Vec<u8> {
+    ffi::batch_generate_ring_vrf_for_validators(
+        ring_keys,
+        prover_key_indices,
+        secret_seeds_data,
+        secret_seed_data_len,
         inputs_data,
         vrf_input_data_len,
     )


### PR DESCRIPTION
Summary:
- Add generateRingVrf for a concrete ticket input / specific attempt.
- Add batchGenerateRingVrfForValidators for validator-major multi-validator generation.
- Reuse prover setup in the existing single-validator batch path.

Tests:
- cargo fmt --all --check -q
- cargo test --verbose
- ../node_modules/.bin/tsc -p tsconfig.json
- wasm-pack build wasm-binding --target web --out-dir pkg
- git diff --check

Public API: yes. This adds exported TypeScript APIs and native/wasm binding exports; existing APIs remain compatible.