### PR TITLE
Read release app ID from secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.PR_APP_ID }}
+          app-id: ${{ secrets.PR_APP_ID }}
           private-key: ${{ secrets.PR_APP_PRIVATE_KEY }}
 
       - name: Create version bump pull request


### PR DESCRIPTION
## Summary
- read `PR_APP_ID` from repository secrets instead of repository variables
- fixes `[@octokit/auth-app] appId option is required` in the Prepare release workflow

## Validation
- `actionlint .github/workflows/*.yml`
- `git diff --check`